### PR TITLE
Total count response(not really)

### DIFF
--- a/app/src/main/java/com/bimobject/themayproject/adapters/RecycleViewAdapter.java
+++ b/app/src/main/java/com/bimobject/themayproject/adapters/RecycleViewAdapter.java
@@ -12,6 +12,7 @@ import android.widget.TextView;
 import com.bimobject.themayproject.R;
 import com.bimobject.themayproject.dto.Product;
 import com.bimobject.themayproject.helpers.OnBottomReachedListener;
+import com.bimobject.themayproject.helpers.OnLoadListener;
 import com.bimobject.themayproject.helpers.OnNewRequestListener;
 import com.bimobject.themayproject.helpers.OnRecycleViewItemClickListener;
 import com.bimobject.themayproject.helpers.RVAHelper;
@@ -29,6 +30,8 @@ public class RecycleViewAdapter extends RecyclerView.Adapter<RecycleViewAdapter.
     private OnRecycleViewItemClickListener onRecycleViewItemClickListener;
     private OnBottomReachedListener onBottomReachedListener;
     private OnNewRequestListener onNewRequestListener;
+    private OnLoadListener onLoadListener;
+    public boolean isLoading;
 
     private RVAHelper helper;
 
@@ -117,6 +120,14 @@ public class RecycleViewAdapter extends RecyclerView.Adapter<RecycleViewAdapter.
 
     public void setOnNewRequestListener(OnNewRequestListener onNewRequestListener) {
         this.onNewRequestListener = onNewRequestListener;
+    }
+
+    public void setOnLoadListener(OnLoadListener onLoadListener) {
+        this.onLoadListener = onLoadListener;
+    }
+
+    public OnLoadListener getOnLoadListener() {
+        return onLoadListener;
     }
 
     public void onNewRequest(Request request){

--- a/app/src/main/java/com/bimobject/themayproject/helpers/OnLoadListener.java
+++ b/app/src/main/java/com/bimobject/themayproject/helpers/OnLoadListener.java
@@ -1,0 +1,10 @@
+package com.bimobject.themayproject.helpers;
+
+/**
+ * Created by octoboss on 2018-05-30.
+ */
+
+public interface OnLoadListener {
+    void startLoading();
+    void finishedLoading();
+}

--- a/app/src/main/java/com/bimobject/themayproject/helpers/RVAHelper.java
+++ b/app/src/main/java/com/bimobject/themayproject/helpers/RVAHelper.java
@@ -51,7 +51,6 @@ public final class RVAHelper {
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
-            context.get().adapter.getOnLoadListener().startLoading();
         }
 
         @Override
@@ -61,8 +60,6 @@ public final class RVAHelper {
             if(request.getPage() == 1) {
                 context.get().adapter.onNewRequest(request);
             }
-
-            context.get().adapter.getOnLoadListener().finishedLoading();
 
         }
 

--- a/app/src/main/java/com/bimobject/themayproject/helpers/RVAHelper.java
+++ b/app/src/main/java/com/bimobject/themayproject/helpers/RVAHelper.java
@@ -49,11 +49,20 @@ public final class RVAHelper {
         }
 
         @Override
+        protected void onPreExecute() {
+            super.onPreExecute();
+            context.get().adapter.getOnLoadListener().startLoading();
+        }
+
+        @Override
         protected void onPostExecute(List<Product> products) {
             context.get().adapter.addAll(products);
 
-            if(request.getPage() == 1)
+            if(request.getPage() == 1) {
                 context.get().adapter.onNewRequest(request);
+            }
+
+            context.get().adapter.getOnLoadListener().finishedLoading();
 
         }
 

--- a/app/src/main/java/com/bimobject/themayproject/helpers/Request.java
+++ b/app/src/main/java/com/bimobject/themayproject/helpers/Request.java
@@ -1,4 +1,5 @@
 package com.bimobject.themayproject.helpers;
+
 import com.bimobject.themayproject.constants.FILTER;
 import com.bimobject.themayproject.constants.VALUES;
 import com.loopj.android.http.RequestParams;
@@ -10,6 +11,9 @@ public class Request {
     private int page;
     private int totalCount;
 
+
+    private String search;
+
     public Request() {
         params = new RequestParams();
         page = 1;
@@ -20,24 +24,26 @@ public class Request {
         return params;
     }
 
-    public void addBrand(String brand){ this.params.add(FILTER.BRAND,brand);
+    public void addBrand(String brand) {
+        this.params.add(FILTER.BRAND, brand);
     }
 
-    public void addCategory(String category){
-        this.params.add(FILTER.CATEGORY,category);
+    public void addCategory(String category) {
+        this.params.add(FILTER.CATEGORY, category);
     }
 
-    public void addSearch(String search){
+    public void addSearch(String search) {
         this.params.put(FILTER.FULLTEXT, search);
+        this.search = search;
     }
 
-    public void addPage(int page){
+    public void addPage(int page) {
         this.params.put("page", page);
 
     }
 
     //TODO:fix a better clearer for when we have several categories and brands.
-    public void clearParams(){
+    public void clearParams() {
         this.params.remove(FILTER.CATEGORY);
     }
 
@@ -64,5 +70,9 @@ public class Request {
 
     public void setTotalCount(int totalCount) {
         this.totalCount = totalCount;
+    }
+
+    public String getSearch() {
+        return search;
     }
 }

--- a/app/src/main/java/com/bimobject/themayproject/ui/mainsearchactivity/MainSearchActivity.java
+++ b/app/src/main/java/com/bimobject/themayproject/ui/mainsearchactivity/MainSearchActivity.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.SearchView;
 
 import com.bimobject.themayproject.R;
 import com.bimobject.themayproject.dto.AllCategories;
@@ -25,9 +26,22 @@ public class MainSearchActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main_search);
 
         Button searchButton = findViewById(R.id.activity_main_btn_search);
-        //EditText searchBox = findViewById(R.id.activity_main_search_et_value);
+        SearchView searchBox = findViewById(R.id.activity_main_search_et_value);
+        searchBox.setIconifiedByDefault(false);
+        searchBox.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String query) {
+                makeSearch(query);
+                return true;
+            }
 
-        searchButton.setOnClickListener(view -> makeSearch());
+            @Override
+            public boolean onQueryTextChange(String newText) {
+                return false;
+            }
+        });
+
+        searchButton.setOnClickListener(view -> makeSearch(searchBox.getQuery().toString()));
 
         /*
         searchBox.setOnKeyListener((v, keyCode, event) -> {
@@ -60,12 +74,9 @@ public class MainSearchActivity extends AppCompatActivity {
         TokenGenerator.start(getString(R.string.client_id), getString(R.string.client_secret));
     }
 
-    private void makeSearch() {
-            EditText searchBox = findViewById(R.id.activity_main_search_et_value);
-            String search = searchBox.getText().toString();
-
+    private void makeSearch(String query) {
             Intent intent = new Intent(MainSearchActivity.this, SearchResultActivity.class);
-            intent.putExtra("search", search);
+            intent.putExtra("search", query);
             startActivity(intent);
         }
 

--- a/app/src/main/java/com/bimobject/themayproject/ui/mainsearchactivity/MainSearchActivity.java
+++ b/app/src/main/java/com/bimobject/themayproject/ui/mainsearchactivity/MainSearchActivity.java
@@ -1,6 +1,7 @@
 package com.bimobject.themayproject.ui.mainsearchactivity;
 
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.KeyEvent;
@@ -8,14 +9,20 @@ import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.ImageView;
 import android.widget.SearchView;
 
 import com.bimobject.themayproject.R;
+import com.bimobject.themayproject.adapters.RecycleViewAdapter;
 import com.bimobject.themayproject.dto.AllCategories;
 import com.bimobject.themayproject.dto.Categories;
+import com.bimobject.themayproject.helpers.OnLoadListener;
+import com.bimobject.themayproject.helpers.Request;
 import com.bimobject.themayproject.helpers.RequestService;
 import com.bimobject.themayproject.helpers.TokenGenerator;
 import com.bimobject.themayproject.ui.searchresultactivity.SearchResultActivity;
+
+import java.lang.ref.WeakReference;
 
 public class MainSearchActivity extends AppCompatActivity {
 
@@ -79,6 +86,5 @@ public class MainSearchActivity extends AppCompatActivity {
             intent.putExtra("search", query);
             startActivity(intent);
         }
-
 
 }

--- a/app/src/main/java/com/bimobject/themayproject/ui/mainsearchactivity/MainSearchActivity.java
+++ b/app/src/main/java/com/bimobject/themayproject/ui/mainsearchactivity/MainSearchActivity.java
@@ -25,10 +25,11 @@ public class MainSearchActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main_search);
 
         Button searchButton = findViewById(R.id.activity_main_btn_search);
-        EditText searchBox = findViewById(R.id.activity_main_search_et_value);
+        //EditText searchBox = findViewById(R.id.activity_main_search_et_value);
 
         searchButton.setOnClickListener(view -> makeSearch());
 
+        /*
         searchBox.setOnKeyListener((v, keyCode, event) -> {
             if (keyCode == KeyEvent.KEYCODE_ENTER) {
                 makeSearch();
@@ -37,7 +38,7 @@ public class MainSearchActivity extends AppCompatActivity {
             return false;
         });
 
-        /*
+
         searchButton.setOnEditorActionListener((v, actionId, event) -> {
 
             switch (actionId) {
@@ -62,7 +63,6 @@ public class MainSearchActivity extends AppCompatActivity {
     private void makeSearch() {
             EditText searchBox = findViewById(R.id.activity_main_search_et_value);
             String search = searchBox.getText().toString();
-
 
             Intent intent = new Intent(MainSearchActivity.this, SearchResultActivity.class);
             intent.putExtra("search", search);

--- a/app/src/main/java/com/bimobject/themayproject/ui/searchresultactivity/SearchResultActivity.java
+++ b/app/src/main/java/com/bimobject/themayproject/ui/searchresultactivity/SearchResultActivity.java
@@ -1,6 +1,8 @@
 package com.bimobject.themayproject.ui.searchresultactivity;
 
+import android.app.Activity;
 import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.design.widget.NavigationView;
@@ -15,30 +17,38 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.SearchView;
 import android.widget.TextView;
 import android.widget.Toast;
 
 import com.bimobject.themayproject.adapters.RecycleViewAdapter;
 import com.bimobject.themayproject.R;
+import com.bimobject.themayproject.helpers.OnLoadListener;
 import com.bimobject.themayproject.helpers.OnNewRequestListener;
 import com.bimobject.themayproject.helpers.RVAHelper;
 import com.bimobject.themayproject.helpers.Request;
 import com.bimobject.themayproject.helpers.TokenGenerator;
 import com.bimobject.themayproject.ui.productinfoactivity.ProductInfoActivity;
 
+import java.lang.ref.WeakReference;
+
 public class SearchResultActivity extends AppCompatActivity
         implements NavigationView.OnNavigationItemSelectedListener {
 
-    private static RecycleViewAdapter adapter;
-    private static String search;
+    public static RecycleViewAdapter adapter;
     private DrawerLayout drawer;
-
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_search_result);
+
+        Request request = new Request();
+        if(getIntent().hasExtra("search")){
+            request.addSearch(getIntent().getStringExtra("search"));
+        }
 
         //DRAWER START
         drawer = findViewById(R.id.drawer_layout);
@@ -50,7 +60,6 @@ public class SearchResultActivity extends AppCompatActivity
         }
         toolbar.setLogo(R.drawable.ic_logo_bimobject_black);
 
-
         ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(
                 this, drawer, R.string.navigation_drawer_open, R.string.navigation_drawer_close);
         drawer.addDrawerListener(toggle);
@@ -60,17 +69,7 @@ public class SearchResultActivity extends AppCompatActivity
         navigationView.setNavigationItemSelectedListener(this);
         //DRAWER END
 
-
-        if (getIntent().hasExtra("search")) {
-            search = getIntent().getStringExtra("search");
-        }
-
-        Request request = new Request();
-        request.addSearch(search);
-
         adapter = new RecycleViewAdapter();
-        adapter.getHelper().makeNewRequest(request);
-
         RecyclerView recyclerView = findViewById(R.id.activity_search_result_rv_list);
         TextView emptyView = findViewById(R.id.activity_search_result_empty_view);
         RecyclerView.LayoutManager layoutManager = new LinearLayoutManager(getApplicationContext());
@@ -115,6 +114,23 @@ public class SearchResultActivity extends AppCompatActivity
                 emptyView.setVisibility(View.GONE);
             }
         });
+
+        adapter.setOnLoadListener(new OnLoadListener() {
+            @Override
+            public void startLoading() {
+                LinearLayout preloader = findViewById(R.id.activity_search_result_list_placeholder);
+                preloader.setVisibility(View.VISIBLE);
+            }
+
+            @Override
+            public void finishedLoading() {
+                LinearLayout preloader = findViewById(R.id.activity_search_result_list_placeholder);
+                preloader.setVisibility(View.INVISIBLE);
+            }
+        });
+
+        adapter.getHelper().makeNewRequest(request);
+
     }
 
     @Override
@@ -144,8 +160,7 @@ public class SearchResultActivity extends AppCompatActivity
 
         SearchView searchView = (SearchView) searchItem.getActionView();
         searchView.setIconified(false);
-        searchView.setQuery(search, false);
-
+        searchView.setQuery(RVAHelper.getRequest().getSearch(), false);
 
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
@@ -200,4 +215,5 @@ public class SearchResultActivity extends AppCompatActivity
     }
 
     //DRAWER FINISHED
+
 }

--- a/app/src/main/java/com/bimobject/themayproject/ui/searchresultactivity/SearchResultActivity.java
+++ b/app/src/main/java/com/bimobject/themayproject/ui/searchresultactivity/SearchResultActivity.java
@@ -96,6 +96,7 @@ public class SearchResultActivity extends AppCompatActivity
             } else {
                 Toast.makeText(SearchResultActivity.this, RVAHelper.getRequest().getTotalCount() + getString(R.string.found_product), Toast.LENGTH_LONG).show();
 
+                /*
                 TextView responseTextValue = findViewById(R.id.activity_search_response_search_term);
                 String search_term = request1.getSearch();
                 if (search_term.length() > 20) {
@@ -108,6 +109,7 @@ public class SearchResultActivity extends AppCompatActivity
 
                 TextView responseTotalFilters = findViewById(R.id.activity_search_response_total_filters_applied);
                 responseTotalFilters.setText("10");
+                */
 
                 recyclerView.setVisibility(View.VISIBLE);
                 emptyView.setVisibility(View.GONE);
@@ -139,9 +141,9 @@ public class SearchResultActivity extends AppCompatActivity
 
         MenuItem searchItem = menu.findItem(R.id.action_search);
 
-        SearchView searchView = (SearchView) searchItem.getActionView();
 
-        searchView.onActionViewExpanded();
+        SearchView searchView = (SearchView) searchItem.getActionView();
+        searchView.setIconified(false);
         searchView.setQuery(search, false);
 
 

--- a/app/src/main/java/com/bimobject/themayproject/ui/searchresultactivity/SearchResultActivity.java
+++ b/app/src/main/java/com/bimobject/themayproject/ui/searchresultactivity/SearchResultActivity.java
@@ -115,20 +115,6 @@ public class SearchResultActivity extends AppCompatActivity
             }
         });
 
-        adapter.setOnLoadListener(new OnLoadListener() {
-            @Override
-            public void startLoading() {
-                LinearLayout preloader = findViewById(R.id.activity_search_result_list_placeholder);
-                preloader.setVisibility(View.VISIBLE);
-            }
-
-            @Override
-            public void finishedLoading() {
-                LinearLayout preloader = findViewById(R.id.activity_search_result_list_placeholder);
-                preloader.setVisibility(View.INVISIBLE);
-            }
-        });
-
         adapter.getHelper().makeNewRequest(request);
 
     }

--- a/app/src/main/java/com/bimobject/themayproject/ui/searchresultactivity/SearchResultActivity.java
+++ b/app/src/main/java/com/bimobject/themayproject/ui/searchresultactivity/SearchResultActivity.java
@@ -18,6 +18,7 @@ import android.view.View;
 import android.widget.SearchView;
 import android.widget.TextView;
 import android.widget.Toast;
+
 import com.bimobject.themayproject.adapters.RecycleViewAdapter;
 import com.bimobject.themayproject.R;
 import com.bimobject.themayproject.helpers.OnNewRequestListener;
@@ -45,9 +46,8 @@ public class SearchResultActivity extends AppCompatActivity
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         if (getSupportActionBar() != null) {
-        getSupportActionBar().setDisplayShowTitleEnabled(false);
+            getSupportActionBar().setDisplayShowTitleEnabled(false);
         }
-
         toolbar.setLogo(R.drawable.ic_logo_bimobject_black);
 
 
@@ -89,13 +89,26 @@ public class SearchResultActivity extends AppCompatActivity
         });
 
         adapter.setOnNewRequestListener(request1 -> {
-            if (request1.getTotalCount() == 0){
+            if (request1.getTotalCount() == 0) {
                 Toast.makeText(SearchResultActivity.this, getString(R.string.zero_results), Toast.LENGTH_LONG).show();
                 recyclerView.setVisibility(View.GONE);
                 emptyView.setVisibility(View.VISIBLE);
-            }
-            else{
+            } else {
                 Toast.makeText(SearchResultActivity.this, RVAHelper.getRequest().getTotalCount() + getString(R.string.found_product), Toast.LENGTH_LONG).show();
+
+                TextView responseTextValue = findViewById(R.id.activity_search_response_search_term);
+                String search_term = request1.getSearch();
+                if (search_term.length() > 20) {
+                    search_term = search_term.substring(0, 20) + "...";
+                }
+                responseTextValue.setText("\"" + search_term + "\"");
+
+                TextView responseTotalCount = findViewById(R.id.activity_search_response_total_count);
+                responseTotalCount.setText(String.valueOf(request1.getTotalCount()));
+
+                TextView responseTotalFilters = findViewById(R.id.activity_search_response_total_filters_applied);
+                responseTotalFilters.setText("10");
+
                 recyclerView.setVisibility(View.VISIBLE);
                 emptyView.setVisibility(View.GONE);
             }
@@ -107,14 +120,6 @@ public class SearchResultActivity extends AppCompatActivity
         super.onPostResume();
         TokenGenerator.start(getString(R.string.client_id), getString(R.string.client_secret));
     }
-
-
-    @Override
-    protected void onPostResume() {
-        super.onPostResume();
-        TokenGenerator.start(getString(R.string.client_id), getString(R.string.client_secret));
-    }
-
 
     //DRAWER CONTINUE
     @Override
@@ -135,8 +140,9 @@ public class SearchResultActivity extends AppCompatActivity
         MenuItem searchItem = menu.findItem(R.id.action_search);
 
         SearchView searchView = (SearchView) searchItem.getActionView();
-        searchView.setIconifiedByDefault(false);
-        searchView.setIconified(false);
+
+        searchView.onActionViewExpanded();
+        searchView.setQuery(search, false);
 
 
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {

--- a/app/src/main/res/layout/activity_main_search.xml
+++ b/app/src/main/res/layout/activity_main_search.xml
@@ -7,7 +7,7 @@
     tools:context="com.bimobject.themayproject.ui.mainsearchactivity.MainSearchActivity"
     tools:layout_editor_absoluteY="81dp">
 
-    <EditText
+    <SearchView
         android:id="@+id/activity_main_search_et_value"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_main_search.xml
+++ b/app/src/main/res/layout/activity_main_search.xml
@@ -48,5 +48,21 @@
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_bim_logo_black_large" />
 
+    <ImageView
+        android:id="@+id/activity_main_search_iv_loading"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginBottom="32dp"
+        android:layout_marginEnd="32dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="32dp"
+        android:adjustViewBounds="true"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/activity_main_btn_search"
+        app:srcCompat="@drawable/progress_animation" />
+
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/content_search.xml
+++ b/app/src/main/res/layout/content_search.xml
@@ -8,6 +8,7 @@
     tools:context=".ui.searchresultactivity.SearchResultActivity"
     tools:showIn="@layout/app_bar_search">
 
+    <!--
     <LinearLayout
         android:id="@+id/activity_search_result_response_info"
         android:layout_width="match_parent"
@@ -68,6 +69,7 @@
             android:gravity="center_vertical"
             android:padding="@dimen/text_view_padding" />
     </LinearLayout>
+    -->
 
 
     <android.support.v7.widget.RecyclerView
@@ -75,7 +77,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
-        app:layout_constraintTop_toBottomOf="@id/activity_search_result_response_info" />
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <TextView
         android:id="@+id/activity_search_result_empty_view"

--- a/app/src/main/res/layout/content_search.xml
+++ b/app/src/main/res/layout/content_search.xml
@@ -87,6 +87,7 @@
         android:text="@string/no_data_available"
         android:visibility="gone" />
 
+    <!--
     <LinearLayout
         android:id="@+id/activity_search_result_list_placeholder"
         android:layout_width="wrap_content"
@@ -109,5 +110,6 @@
             android:src="@drawable/progress_animation"
            />
     </LinearLayout>
+    -->
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/content_search.xml
+++ b/app/src/main/res/layout/content_search.xml
@@ -8,18 +8,81 @@
     tools:context=".ui.searchresultactivity.SearchResultActivity"
     tools:showIn="@layout/app_bar_search">
 
+    <LinearLayout
+        android:id="@+id/activity_search_result_response_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="@dimen/general_margin"
+        android:text="TextView"
+        app:layout_constraintBottom_toTopOf="@+id/activity_search_result_rv_list"
+        app:layout_constraintEnd_toStartOf="@+id/activity_search_result_rv_list"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/activity_search_response_search_term_desc"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
+            android:padding="@dimen/text_view_padding"
+            android:text="@string/search_term_desc" />
+
+        <TextView
+            android:id="@+id/activity_search_response_search_term"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@color/colorLighterGrey"
+            android:gravity="center_vertical"
+            android:padding="@dimen/text_view_padding" />
+
+        <TextView
+            android:id="@+id/activity_search_response_total_count_desc"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
+            android:padding="@dimen/text_view_padding"
+            android:text="@string/total_count_desc" />
+
+        <TextView
+            android:id="@+id/activity_search_response_total_count"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@color/colorLighterGrey"
+            android:gravity="center_vertical"
+            android:padding="@dimen/text_view_padding" />
+
+        <TextView
+            android:id="@+id/activity_search_response_total_filters_applied_desc"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:gravity="center_vertical"
+            android:padding="@dimen/text_view_padding"
+            android:text="@string/filters_applied_desc" />
+
+        <TextView
+            android:id="@+id/activity_search_response_total_filters_applied"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:background="@color/colorLighterGrey"
+            android:gravity="center_vertical"
+            android:padding="@dimen/text_view_padding" />
+    </LinearLayout>
+
+
     <android.support.v7.widget.RecyclerView
         android:id="@+id/activity_search_result_rv_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_alignParentStart="true"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/activity_search_result_response_info" />
+
     <TextView
         android:id="@+id/activity_search_result_empty_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:gravity="center"
-        android:visibility="gone"
-        android:text="@string/no_data_available" />
+        android:text="@string/no_data_available"
+        android:visibility="gone" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/content_search.xml
+++ b/app/src/main/res/layout/content_search.xml
@@ -87,4 +87,27 @@
         android:text="@string/no_data_available"
         android:visibility="gone" />
 
+    <LinearLayout
+        android:id="@+id/activity_search_result_list_placeholder"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/activity_search_result_list_placeholder_image"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginBottom="32dp"
+            android:layout_marginEnd="32dp"
+            android:layout_marginStart="32dp"
+            android:layout_marginTop="32dp"
+            android:cropToPadding="false"
+            android:src="@drawable/progress_animation"
+           />
+    </LinearLayout>
+
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/menu/search.xml
+++ b/app/src/main/res/menu/search.xml
@@ -9,7 +9,7 @@
         android:actionLayout="@layout/search_bar_edit_text"
         app:actionViewClass="android.widget.SearchView"
         app:showAsAction="ifRoom|collapseActionView"
-        android:iconifiedByDefault="false" />
+        />
 
     <item
         android:id="@+id/action_drawer"

--- a/app/src/main/res/menu/search.xml
+++ b/app/src/main/res/menu/search.xml
@@ -8,9 +8,9 @@
         android:title="Search"
         android:actionLayout="@layout/search_bar_edit_text"
         app:actionViewClass="android.widget.SearchView"
-        app:showAsAction="ifRoom|collapseActionView" />
+        app:showAsAction="ifRoom|collapseActionView"
+        android:iconifiedByDefault="false" />
 
-    <!-- TODO add filter icon -->
     <item
         android:id="@+id/action_drawer"
         android:icon="@drawable/ic_action_sort"

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -4,4 +4,5 @@
     <dimen name="general_font_size">16sp</dimen>
     <dimen name="small_font_size">14sp</dimen>
     <dimen name="headline_size">18sp</dimen>
+    <dimen name="text_view_padding">2dp</dimen>
 </resources>

--- a/app/src/main/res/values/secrets.xml
+++ b/app/src/main/res/values/secrets.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="client_id">65odCwPjkOETNsgGelXXH2RV5iyhNUNU</string>
+    <string name="client_secret">nWhWEppDsHGAn55bowpUbYKPPrtyivG5hKKcvGeGaXdxLlt3Ud7eK33R5kUwjVpe</string>
+</resources>

--- a/app/src/main/res/values/string.xml
+++ b/app/src/main/res/values/string.xml
@@ -7,4 +7,7 @@
     <string name="found_product">&#160;products found</string>
     <string name="no_data_available">No data available</string>
     <string name="zero_results">0 products found. Try something else!</string>
+    <string name="search_term_desc">Search:&#160;</string>
+    <string name="total_count_desc">&#160;Results:&#160;</string>
+    <string name="filters_applied_desc">&#160;Filters:&#160;</string>
 </resources>


### PR DESCRIPTION
This branch comes with a responsehandler showing the user current searchterm, no. of results and no. of filters applied. After consideration we decided to comment it away and keep the result view as it is (with a Toast showing no. of results). This is related to UX-considerations. However the response functionality is easily implementable if we wish.

Also this patch fixes a problem where two searchResultActivites start on top of eachother, resulting in buggy behaviour. We removed the editText box in MainSearchActivity and replaced it with a searchView. We think it looks better and better supports its functionality as a search box.

Also we experimented with a preloader when the recycleView first loads from MainSearchActivity. However I removed it in the last commit as I think it looks weird. Although the added interface (OnNewRequestLoadListener) is still available if we would like to implement some type of preloader for the list in the future.

So basically this patch does not really add much new behaviour, but non-implemented functionality  for us to add if we wish.